### PR TITLE
V3: Option to have lazy DSC<> initialization. Option to exclude static model

### DIFF
--- a/ODataConnectedService/src/CodeGeneration/V3CodeGenDescriptor.cs
+++ b/ODataConnectedService/src/CodeGeneration/V3CodeGenDescriptor.cs
@@ -16,6 +16,67 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
 {
     internal class V3CodeGenDescriptor : BaseCodeGenDescriptor
     {
+        const string loadServiceModelAssignment = "this.Format.LoadServiceModel = GeneratedEdmModel.GetInstance;";
+        const string dynamicModelLoader =
+        @"private abstract class RuntimeEdmModel
+        {
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute(""System.Data.Services.Design"", ""1.0.0"")]
+            private static global::System.Collections.Generic.Dictionary<string, global::Microsoft.Data.Edm.IEdmModel> models = new global::System.Collections.Generic.Dictionary<string, global::Microsoft.Data.Edm.IEdmModel>(global::System.StringComparer.OrdinalIgnoreCase);
+
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute(""System.Data.Services.Design"", ""1.0.0"")]
+            private static object modelsCacheLock = new object();
+
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute(""System.Data.Services.Design"", ""1.0.0"")]
+            public static global::Microsoft.Data.Edm.IEdmModel LoadModel(global::System.Data.Services.Client.DataServiceContext context)
+            {
+                var metadataUri = context.GetMetadataUri();
+                global::Microsoft.Data.Edm.IEdmModel model = null;
+                if (!models.TryGetValue(metadataUri.AbsoluteUri, out model))
+                {
+                    lock (modelsCacheLock)
+                    {
+                        if (!models.TryGetValue(metadataUri.AbsoluteUri, out model))
+                        {
+                            var request = (global::System.Net.HttpWebRequest)global::System.Net.WebRequest.Create(metadataUri);
+                            request.Credentials = context.Credentials;
+
+                            using (var response = request.EndGetResponse(request.BeginGetResponse(null, null)))
+                            using (var stream = response.GetResponseStream())
+                            using (var reader = global::System.Xml.XmlReader.Create(stream))
+                            {
+                                model = global::Microsoft.Data.Edm.Csdl.EdmxReader.Parse(reader);
+                                models.Add(metadataUri.AbsoluteUri, model);
+                            }
+                        }
+                    }
+                }
+                return model;
+            }
+        }";
+
+        const string collectionReplacer =
+        @"private $1 __$2 = null;
+
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute(""System.Data.Services.Design"", ""1.0.0"")]
+        private $1 _$2
+        {
+            get
+            {
+                if (__$2 == null && !__$2Initialized)
+                    $2 = new $1(null, global::System.Data.Services.Client.TrackingMode.None);
+                return __$2;
+            }
+            set
+            {
+                __$2 = value;
+                __$2Initialized = true;
+            }
+        }
+
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute(""System.Data.Services.Design"", ""1.0.0"")]
+        bool __$2Initialized;
+";
+
         public V3CodeGenDescriptor(string metadataUri, ConnectedServiceHandlerContext context, Project project)
             : base(metadataUri, context, project)
         {
@@ -82,6 +143,58 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
                         {
                             await this.Context.Logger.WriteMessageAsync(LoggerMessageCategory.Warning, err.Message);
                         }
+                    }
+                }
+
+                if (this.ServiceConfiguration.LazyInitializedEntityCollections || this.ServiceConfiguration.UseRuntimeModel)
+                {
+                    await this.Context.Logger.WriteMessageAsync(LoggerMessageCategory.Information, "Cleaning proxy...");
+                    string original = null;
+                    using (var textReader = File.OpenText(tempFile))
+                    {
+                        original = await textReader.ReadToEndAsync();
+                    }
+                    string modified = null;
+
+                    if (this.ServiceConfiguration.LazyInitializedEntityCollections)
+                    {
+                        string pattern = null;
+                        if (generator.UseDataServiceCollection)
+                        {
+                            await this.Context.Logger.WriteMessageAsync(LoggerMessageCategory.Information, "Proxy - injecting lazy initialization of DataServiceCollections");
+                            pattern = @"private (.+) _(.+) = new global::System.Data.Services.Client.DataServiceCollection\<(.+)\>\(null, global::System.Data.Services.Client.TrackingMode.None\);";
+                        }
+                        else
+                        {
+                            await this.Context.Logger.WriteMessageAsync(LoggerMessageCategory.Information, "Proxy - injecting lazy initialization of ObservableCollections");
+                            pattern = @"private (.+) _(.+) = new global::System.Collections.ObjectModel.Collection\<(.+)\>\(\);";
+                        }
+                        modified = Regex.Replace(original, pattern, collectionReplacer);
+                    }
+                    else
+                        modified = original;
+
+                    if (this.ServiceConfiguration.UseRuntimeModel)
+                    {
+                        await this.Context.Logger.WriteMessageAsync(LoggerMessageCategory.Information, "Proxy - removing static model");
+                        int loadServiceModelAssignmentIndex = modified.IndexOf(loadServiceModelAssignment);
+                        if (loadServiceModelAssignmentIndex >= 0)
+                        {
+                            modified = string.Concat(modified.Substring(0, loadServiceModelAssignmentIndex), "this.Format.LoadServiceModel = () => RuntimeEdmModel.LoadModel(this);", modified.Substring(loadServiceModelAssignmentIndex + loadServiceModelAssignment.Length));
+                            int classStart = modified.IndexOf("private abstract class GeneratedEdmModel");
+                            int classEnd = modified.IndexOf("return global::System.Xml.XmlReader.Create(new global::System.IO.StringReader(edmxToParse));");
+                            if (classStart >= 0 && classEnd > 0)
+                            {
+                                classEnd = modified.IndexOf('}', classEnd + 1);
+                                classEnd = modified.IndexOf('}', classEnd + 1) + 1;
+                                modified = string.Concat(modified.Substring(0, classStart), dynamicModelLoader, modified.Substring(classEnd));
+                            }
+                        }
+                    }
+                    await this.Context.Logger.WriteMessageAsync(LoggerMessageCategory.Information, "Proxy generation done. Writing output files...");
+                    using (StreamWriter writer = File.CreateText(tempFile))
+                    {
+                        await writer.WriteAsync(modified);
                     }
                 }
 

--- a/ODataConnectedService/src/Models/ServiceConfiguration.cs
+++ b/ODataConnectedService/src/Models/ServiceConfiguration.cs
@@ -14,6 +14,8 @@ namespace Microsoft.OData.ConnectedService.Models
         public bool UseNameSpacePrefix { get; set; }
         public string NamespacePrefix { get; set; }
         public bool UseDataServiceCollection { get; set; }
+        public bool UseRuntimeModel { get; set; }
+        public bool LazyInitializedEntityCollections { get; set; }
     }
 
     internal class ServiceConfigurationV4 : ServiceConfiguration

--- a/ODataConnectedService/src/ODataConnectedServiceWizard.cs
+++ b/ODataConnectedService/src/ODataConnectedServiceWizard.cs
@@ -77,6 +77,8 @@ namespace Microsoft.OData.ConnectedService
                         advancedSettingsViewModel.UseNamespacePrefix = serviceConfig.UseNameSpacePrefix;
                         advancedSettingsViewModel.NamespacePrefix = serviceConfig.NamespacePrefix;
                         advancedSettingsViewModel.UseDataServiceCollection = serviceConfig.UseDataServiceCollection;
+                        advancedSettingsViewModel.UseRuntimeModel = serviceConfig.UseRuntimeModel;
+                        advancedSettingsViewModel.LazyInitializedEntityCollections = serviceConfig.LazyInitializedEntityCollections;
 
                         if (serviceConfig.EdmxVersion == Common.Constants.EdmxVersion4)
                         {
@@ -130,6 +132,8 @@ namespace Microsoft.OData.ConnectedService
             serviceConfiguration.Endpoint = ConfigODataEndpointViewModel.Endpoint;
             serviceConfiguration.EdmxVersion = ConfigODataEndpointViewModel.EdmxVersion;
             serviceConfiguration.UseDataServiceCollection = AdvancedSettingsViewModel.UseDataServiceCollection;
+            serviceConfiguration.UseRuntimeModel = AdvancedSettingsViewModel.UseRuntimeModel;
+            serviceConfiguration.LazyInitializedEntityCollections = AdvancedSettingsViewModel.LazyInitializedEntityCollections;
             serviceConfiguration.GeneratedFileNamePrefix = AdvancedSettingsViewModel.GeneratedFileName;
             serviceConfiguration.UseNameSpacePrefix = AdvancedSettingsViewModel.UseNamespacePrefix;
             if (AdvancedSettingsViewModel.UseNamespacePrefix && !string.IsNullOrEmpty(AdvancedSettingsViewModel.NamespacePrefix))

--- a/ODataConnectedService/src/ViewModels/AdvancedSettingsViewModel.cs
+++ b/ODataConnectedService/src/ViewModels/AdvancedSettingsViewModel.cs
@@ -17,6 +17,8 @@ namespace Microsoft.OData.ConnectedService.ViewModels
         public bool IgnoreUnexpectedElementsAndAttributes { get; set; }
         public string GeneratedFileName { get; set; }
         public bool IncludeT4File { get; set; }
+        public bool UseRuntimeModel { get; set; }
+        public bool LazyInitializedEntityCollections { get; set; }
 
         public AdvancedSettingsViewModel() : base()
         {
@@ -51,6 +53,8 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             this.UseNamespacePrefix = false;
             this.NamespacePrefix = null;
             this.UseDataServiceCollection = true;
+            this.UseRuntimeModel = false;
+            this.LazyInitializedEntityCollections = true;
             this.IgnoreUnexpectedElementsAndAttributes = false;
             this.EnableNamingAlias = false;
             this.GeneratedFileName = Common.Constants.DefaultReferenceFileName;

--- a/ODataConnectedService/src/Views/AdvancedSettings.xaml
+++ b/ODataConnectedService/src/Views/AdvancedSettings.xaml
@@ -36,6 +36,14 @@
                          HorizontalAlignment="Left" TextWrapping="Wrap" VerticalAlignment="Center" Width="250" Margin="20, 0, 0, 5"/>
                 <CheckBox x:Name="UseDSC" Content="Enable entity and property tracking" IsChecked="{Binding UseDataServiceCollection}"
                           HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0, 5, 0, 0" />
+                <CheckBox x:Name="UseLazyDSC" Content="Lazy entity collection initialization" IsChecked="{Binding LazyInitializedEntityCollections}"
+                          HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0, 5, 0, 0" />
+                <CheckBox x:Name="ExcludeModel" IsChecked="{Binding UseRuntimeModel}"
+                          HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0, 5, 0, 0" >
+                    <TextBlock TextWrapping="Wrap" Margin="0, 0, 40, 0">
+                        Load model runtime (Produces smaller assembly, but will issue a request runtime for the metadata document.)
+                    </TextBlock>
+                </CheckBox>
             </StackPanel>
             <StackPanel x:Name="AdvancedSettingsForv4" HorizontalAlignment="Left" Margin="10, 5, 0, 0" VerticalAlignment="Top">
                 <CheckBox x:Name="EnableCamelCase" Content="Use c# casing style" IsChecked="{Binding EnableNamingAlias}"


### PR DESCRIPTION
**This PR fixes issues #45 and #44**

This PR adds two new options (checkboxes) to the V1-3 advanced codegen options.

For V4 - it should be even simpler to do as you have the T4 codegen approach.
