### PR TITLE
Enable delay signing in RestierScaffolding

### DIFF
--- a/RestierScaffolding/src/Microsoft.Restier.Scaffolding/Microsoft.Restier.Scaffolding.csproj
+++ b/RestierScaffolding/src/Microsoft.Restier.Scaffolding/Microsoft.Restier.Scaffolding.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),Scaffolding.sln))\tools\Scaffolding.settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/RestierScaffolding/src/Microsoft.Restier.Scaffolding/Scaffolders/ConfigScaffolder.cs
+++ b/RestierScaffolding/src/Microsoft.Restier.Scaffolding/Scaffolders/ConfigScaffolder.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Restier.Scaffolding
         }
 
         [SuppressMessage("Microsoft.Design", "CA1002:DoNotExposeGenericLists", Justification = "This is an internal API.")]
-        protected internal void AddScaffoldDependencies(List<NuGetPackage> packages)
+        protected internal override void AddScaffoldDependencies(List<NuGetPackage> packages)
         {
             if (packages == null)
             {

--- a/RestierScaffolding/tools/Scaffolding.settings.targets
+++ b/RestierScaffolding/tools/Scaffolding.settings.targets
@@ -13,7 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <NoWarn>1591</NoWarn>
 
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>


### PR DESCRIPTION
Enable delay signing in RestierScaffolding by including Scaffolding.settings.targets.

However, due to warnings, disable warnings as errors.
A fix for a CS0507 error in ConfigScaffolder.cs is included.