### PR TITLE
Update CodeGeneratorUtils.cs

### DIFF
--- a/ODataConnectedService/src/Common/CodeGeneratorUtils.cs
+++ b/ODataConnectedService/src/Common/CodeGeneratorUtils.cs
@@ -31,7 +31,7 @@ namespace Microsoft.OData.ConnectedService.Common
                 }
             }
 
-            return null;
+            return String.Empty;
         }
     }
 }


### PR DESCRIPTION
PR addresses issue [#64](https://github.com/OData/lab/issues/64), where 

> The "OData Connected Service" wizard invariably fails in the "Finish" step with this error message: "Adding OData Connected Service to the project failed: Value cannot be null. Parameter name: path1".

Problem:
> I have the same problem.
> Visual Studio 2017 Community 15.2.
> 
> I tried to debug it using another instance of visual studio. I got this error:
> 
> `Could not load file or assembly 'Microsoft.VisualStudio.ConnectedServices.Package2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. The system cannot find the file specified.`
> And, Right after it I got:
> 
> "Value cannot be null.\r\nParameter name: path1"

> I found a temporary solution:
> Go to registry:
> [HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Microsoft WCF Data Services]
> 
> I my case I found VS 2010 Tooling key.
> I made a duplicate of that key and renamed it to VS 2014 Tooling.
> 
> Now it's working fine.
> 
> But this problem can be solved easily by changing the source code:
> 
> In V3CodeGenDescriptor.cs#L32 just needs to be checked that if string.IsNullOrEmpty(wcfDSInstallLocation) and if it is then jump to the else statement.
> 
> And this will fix the bug.