### PR TITLE
Added TargetOpenAPIVersion CommandOption.

### DIFF
--- a/OpenApi/OData2OpenApi/OData2OpenApi/Configuration.cs
+++ b/OpenApi/OData2OpenApi/OData2OpenApi/Configuration.cs
@@ -72,7 +72,14 @@ namespace Microsoft.OData2OpenApi.ConsoleApp
         /// </summary>
         [CommandOption("--PrefixTypeBeforeKey=[true/false] : Enable prefix entity type name before single key.")]
         public bool PrefixTypeBeforeKey { get; set; } = true;
-#endregion
+
+        /// <summary>
+        /// Gets/set the target OpenAPI version.
+        /// </summary>
+        [CommandOption("--TargetOpenAPIVersion=[value] : Select the target API version")]
+        public string TargetOpenAPIVersion { get; set; }
+
+        #endregion
 
         /// <summary>
         /// Gets the boolean value indicating whether the input is local file or not.
@@ -80,9 +87,15 @@ namespace Microsoft.OData2OpenApi.ConsoleApp
         public bool IsLocalFile { get; private set; }
 
         /// <summary>
+        /// Gets the spec version to convert to format.
+        /// </summary>
+        public OpenApiSpecVersion SpecVersion { get; private set; } = OpenApiSpecVersion.OpenApi3_0;
+
+        /// <summary>
         /// Gets the output format.
         /// </summary>
         public OpenApiFormat Format { get; private set; } = OpenApiFormat.Json;
+
 
         /// <summary>
         /// Validate the configuration.
@@ -102,6 +115,11 @@ namespace Microsoft.OData2OpenApi.ConsoleApp
                 {
                     throw new Exception($"File '{ InputCsdl }' is not existed.\n");
                 }
+            }
+
+            if (TargetOpenAPIVersion == "2")
+            {
+                SpecVersion = OpenApiSpecVersion.OpenApi2_0;
             }
 
             if (String.IsNullOrWhiteSpace(OutputFileName))

--- a/OpenApi/OData2OpenApi/OData2OpenApi/Configuration.cs
+++ b/OpenApi/OData2OpenApi/OData2OpenApi/Configuration.cs
@@ -76,7 +76,7 @@ namespace Microsoft.OData2OpenApi.ConsoleApp
         /// <summary>
         /// Gets/set the target OpenAPI version.
         /// </summary>
-        [CommandOption("--TargetOpenAPIVersion=[value] : Select the target API version")]
+        [CommandOption("--TargetOpenAPIVersion=[value] : Select the target API version (2 or 3)")]
         public string TargetOpenAPIVersion { get; set; }
 
         #endregion

--- a/OpenApi/OData2OpenApi/OData2OpenApi/OpenApiGenerator.cs
+++ b/OpenApi/OData2OpenApi/OData2OpenApi/OpenApiGenerator.cs
@@ -29,7 +29,7 @@ namespace Microsoft.OData2OpenApi.ConsoleApp
             using (FileStream fs = File.Create(config.OutputFileName))
             {
                 OpenApiDocument document = edmModel.ConvertToOpenApi(settings);
-                document.Serialize(fs, OpenApi.OpenApiSpecVersion.OpenApi3_0, config.Format);
+                document.Serialize(fs, config.SpecVersion, config.Format);
                 fs.Flush();
             }
 


### PR DESCRIPTION
I want to be able to generate an OpenAPI V2 file from the Microsoft Graph metadata.

I've made a small change to the OData2OpenAPI tool to allow the user to specify the TargetOpenAPIVersion as a command option. It will default to 3 unless 2 is specified.

An example of the command options would be;
--csdl=c:\temp\cleanMetadataWithDescriptionsv1.0.xml --output=swaggerV2.json --TargetOpenAPIVersion=2

I've never created a pull request to an open repo before, so I hope I'm doing this right.

Thanks